### PR TITLE
Update labels and documentation links for plugins

### DIFF
--- a/Dorkag/labels.list
+++ b/Dorkag/labels.list
@@ -15,12 +15,12 @@
 
     <secondary-label id="experimental" name="Experimental" color="purple">This is an experimental feature
     </secondary-label>
-    <secondary-label id="azd_version" name="V2025.2.36" color="blue">New in version 2025.2
+    <secondary-label id="azd_version" name="V2025.2.37" color="blue">New in version 2025.2
     </secondary-label>
-    <secondary-label id="gbrowser_version" name="V2025.2.3" color="tangerine">New in version 2025.2
+    <secondary-label id="gbrowser_version" name="V2025.2.4" color="tangerine">New in version 2025.2
     </secondary-label>
-    <secondary-label id="codecov_version" name="V2025.2.11" color="green">New in version 2025.2
+    <secondary-label id="codecov_version" name="V2025.2.12" color="green">New in version 2025.2
     </secondary-label>
-    <secondary-label id="queryflag_version" name="V2025.2.4" color="blue">New in version 2025.2
+    <secondary-label id="queryflag_version" name="V2025.2.5" color="blue">New in version 2025.2
     </secondary-label>
 </labels>

--- a/README.md
+++ b/README.md
@@ -12,24 +12,24 @@ Visit the documentation site: [https://edgafner.github.io](https://edgafner.gith
 
 ## 🔌 Plugins Suite
 
-### [AZD - Azure DevOps Integration](https://edgafner.github.io/azdlib.html)
+### [AZD - Azure DevOps Integration](https://edgafner.github.io/azd.html)
 
 Complete Azure DevOps integration for JetBrains IDEs. Manage pull requests, pipelines, and work items without leaving
 your IDE.
 
-### [GBrowser - Browser Integration](https://edgafner.github.io/gbrowserlib.html)
+### [GBrowser - Browser Integration](https://edgafner.github.io/gbrowser.html)
 
 Seamlessly integrate browser functionality into your development workflow.
 
-### [Codecov - Code Coverage](https://edgafner.github.io/codecovlib.html)
+### [Codecov - Code Coverage](https://edgafner.github.io/codecov.html)
 
 Visualize and track code coverage directly in your IDE.
 
-### [QueryFlag - Query Management](https://edgafner.github.io/queryflaglib.html)
+### [QueryFlag - Query Management](https://edgafner.github.io/queryflag.html)
 
 Efficient query management and execution tools.
 
-### [RunLikeMe - Run Configuration Management](https://edgafner.github.io/runlikemelib.html)
+### [RunLikeMe - Run Configuration Management](https://edgafner.github.io/runlikeme.html)
 
 Share and manage run configurations across your team.
 


### PR DESCRIPTION
This pull request includes the following updates:
- Updates to version labels in `Dorkag/labels.list` for AZD, GBrowser, Codecov, and QueryFlag.
- Corrected and standardized documentation links in `README.md` for plugins including AZD, GBrowser, Codecov, QueryFlag, and RunLikeMe.

No breaking changes are introduced.