### PR TITLE
Update version labels and configuration files

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbrsdk_jcef-21 (2)" project-jdk-type="JavaSDK" />
 </project>

--- a/Dorkag/labels.list
+++ b/Dorkag/labels.list
@@ -14,7 +14,7 @@
 
     <secondary-label id="experimental" name="Experimental" color="purple">This is an experimental feature
     </secondary-label>
-    <secondary-label id="azd_version" name="V2025.3.61" color="blue">New in version 2025.3
+    <secondary-label id="azd_version" name="V2026.1.15" color="blue">New in version 2026.1
     </secondary-label>
     <secondary-label id="gbrowser_version" name="V2026.1.5" color="tangerine">New in version 2026.1
     </secondary-label>

--- a/Dorkag/labels.list
+++ b/Dorkag/labels.list
@@ -14,11 +14,11 @@
 
     <secondary-label id="experimental" name="Experimental" color="purple">This is an experimental feature
     </secondary-label>
-    <secondary-label id="azd_version" name="V2026.1.15" color="blue">New in version 2026.1
+    <secondary-label id="azd_version" name="V2026.1.33" color="blue">New in version 2026.1
     </secondary-label>
-    <secondary-label id="gbrowser_version" name="V2026.1.5" color="tangerine">New in version 2026.1
+    <secondary-label id="gbrowser_version" name="V2026.1.7" color="tangerine">New in version 2026.1
     </secondary-label>
-    <secondary-label id="codecov_version" name="V2026.1.4" color="green">New in version 2026.1
+    <secondary-label id="codecov_version" name="V2026.1.10" color="green">New in version 2026.1
     </secondary-label>
     <secondary-label id="queryflag_version" name="V2026.1.3" color="blue">New in version 2026.1
     </secondary-label>

--- a/Dorkag/labels.list
+++ b/Dorkag/labels.list
@@ -18,7 +18,7 @@
     </secondary-label>
     <secondary-label id="gbrowser_version" name="V2026.1.5" color="tangerine">New in version 2026.1
     </secondary-label>
-    <secondary-label id="codecov_version" name="V2026.1.3" color="green">New in version 2026.1
+    <secondary-label id="codecov_version" name="V2026.1.4" color="green">New in version 2026.1
     </secondary-label>
     <secondary-label id="queryflag_version" name="V2026.1.3" color="blue">New in version 2026.1
     </secondary-label>


### PR DESCRIPTION
```markdown
### Description

This pull request includes the following updates:
- Updates version labels for AZD, GBrowser, and Codecov in relevant configuration files.
- Adds an XML declaration and external storage configuration to `misc.xml`.
- Fixes Codecov version to `V2026.1.4`.
- Updates AZD version to `V2026.1.15` for the official 2026.1 release.

### Related Issues

_No related issues associated._

### Type of Change

Please delete options that are not relevant:

- [x] Maintenance/Chore
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
```